### PR TITLE
Hide Promoted Reddit Content, adds host_permissions and MutationObserver

### DIFF
--- a/manifest.json
+++ b/manifest.json
@@ -1,6 +1,6 @@
 {
   "name": "Dejunk",
-  "description": "Base Level Extension",
+  "description": "Dejunkify the internet by removing junk content (promoted or otherwise unrelated content to a page's specific purpose) from websites.",
   "version": "1.0",
   "manifest_version": 3,
   "action": {
@@ -9,8 +9,12 @@
   },
   "content_scripts": [
     {
-      "matches": ["https://*.quora.com/*", "https://www.quora.com/*"],
+      "matches": ["https://*.quora.com/*", "https://www.quora.com/*", "https://*.reddit.com/*"],
       "js": ["scripts/content.js"]
     }
-  ]
+  ],
+  "host_permissions": [
+  "https://*.quora.com/*",
+  "https://*.reddit.com/*"
+]
 }

--- a/scripts/content.js
+++ b/scripts/content.js
@@ -1,17 +1,21 @@
-// Hide all promoted answers on Quora.
-const elements = document.querySelectorAll('.dom_annotate_ad_promoted_answer');
-elements.forEach((el) => el.style.display = 'none');
+// Hide all 'promoted' content on Quora & Reddit.
+function hideTargetElements() {
+  const elements = document.querySelectorAll('.dom_annotate_ad_promoted_answer, .promotedlink');
 
-// Theory: This code hides 'Related' answers on Quora.
-// Currently it hides all answers containing the word 'Related', too. Commented out for now.
+  elements.forEach((el) => {
+    el.style.display = 'none';
+  });
+}
 
-// const spans = document.querySelectorAll('span');
+// Initial run
+hideTargetElements();
 
-// spans.forEach(span => {
-//   if (span.textContent.includes('Related')) {
-//     const parent = span.closest('div');
-//     if (parent) {
-//       parent.style.display = 'none'
-//     }
-//   }
-// });
+// Watch for dynamic content
+const observer = new MutationObserver(() => {
+  hideTargetElements();
+});
+
+observer.observe(document.body, {
+  childList: true,
+  subtree: true
+});


### PR DESCRIPTION
This PR widens the matcher for Reddit pages, adds `host_permissions` to ensure the extension can run on specified pages, adds a class selector for unwanted promoted content on Reddit, and modifies the `content.js` code to utilize a `MutationObserver` to watch for DOM changes on dynamic sites and pages with infinite scroll, running the hiding function again when changes occur to ensure all specified content is always hidden.