### PR TITLE
Bug/unmatched url handling

### DIFF
--- a/manifest.json
+++ b/manifest.json
@@ -14,11 +14,10 @@
     }
   ],
   "permissions": [
-    "activeTab",
     "storage"
   ],
   "host_permissions": [
   "https://*.quora.com/*",
   "https://*.reddit.com/*"
-]
+  ]
 }

--- a/popup/popup.css
+++ b/popup/popup.css
@@ -56,6 +56,18 @@ body {
   transition: .4s;
 }
 
+input:disabled + .slider {
+  background-color: #ccc;
+}
+
+input:disabled:checked + .slider {
+  background-color: #ccc;
+}
+
+.disabled {
+  color: #ccc;
+}
+
 input:checked + .slider {
   background-color: #23c91a;
 }

--- a/popup/popup.html
+++ b/popup/popup.html
@@ -4,7 +4,7 @@
     <link rel="stylesheet" href="./popup.css">
   </head>
   <body>
-    <h1>Dejunkify</h1>
+    <h1>Dejunk</h1>
     <p class="slider-label">Hide Sponsored Reddit Posts:</p>
     <label class="switch">
       <input type="checkbox" id="hidePromotedRedditContent" />

--- a/scripts/popup.js
+++ b/scripts/popup.js
@@ -2,10 +2,12 @@
 chrome.tabs.query({ active: true, lastFocusedWindow: true }, (tabs) => {
   // Get all checkboxes in the popup
   const checkboxes = document.querySelectorAll("input[type='checkbox']");
+  const sliderLabels = document.querySelectorAll("p.slider-label");
 
   // If no active tab with manifest-allowed url, disable all checkboxes and display a message
   if (!tabs[0].url) {
     checkboxes.forEach((checkbox) => checkbox.disabled = true);
+    sliderLabels.forEach((label) => label.className = "slider-label disabled");
     document.body.insertAdjacentHTML("beforeend", "<h3>This site not currently supported by Dejunk.</h3>");
   }
 


### PR DESCRIPTION
This PR fixes a bug introduced by #7 that caused the Dejunk extension popup not to disable feature toggles or render the warning message on unsupported web pages.

It also enhances styling through the use of pure CSS and JavaScript class manipulation of DOM elements, making the disabled state clearer for end users.

Closes #8 