### PR TITLE
Feature/youtube lives

### DIFF
--- a/popup/popup.css
+++ b/popup/popup.css
@@ -17,7 +17,7 @@ hr {
   width: 100%;
   border: 0;
   border-top: 1px solid #ccc;
-  margin: 10px 0;
+  margin: 5px 0;
 }
 
 .slider-label {
@@ -36,7 +36,7 @@ hr {
   align-items: center;
   justify-content: space-between;
   width: 95%;
-  padding: 0 5px;
+  margin: 0 5px 5px 5px;
 }
 
 .toggle-row p {

--- a/popup/popup.html
+++ b/popup/popup.html
@@ -40,6 +40,13 @@
           <span class="slider round"></span>
         </label>
       </div>
+      <div class="toggle-row">
+        <p>Hide Live Videos:</p>
+        <label class="switch">
+          <input type="checkbox" id="youtubeLives" />
+          <span class="slider round"></span>
+        </label>
+      </div>
     </div>
     <script src="../scripts/popup.js"></script>
   </body>

--- a/scripts/content.js
+++ b/scripts/content.js
@@ -116,14 +116,24 @@ function hideYoutubeShorts(result) {
   }
 }
 
+// WeakSet to keep track of hidden YouTube live elements
+// This allows us to avoid hiding the same element multiple times
+// Improves performance and prevents unnecessary DOM manipulation
+const hiddenYoutubeLives = new WeakSet();
+
 function hideYoutubeLives(result) {
   if (result === true) {
     // Hide all livestreams on YouTube
     const elements = document.querySelectorAll('.badge-style-type-live-now-alternate');
     for (const el of elements) {
       const element = el.closest('ytd-rich-item-renderer');
-      if (element) {
+      // Check if the element is already hidden
+      if (element && !hiddenYoutubeLives.has(element)) {
+        // Hide the element by adding a class
+        // This class is defined in the injected style above
         element.classList.add('dejunk-hide');
+        // Add the element to the WeakSet to track it
+        hiddenYoutubeLives.add(element);
       }
     }
   } else if (result === false) {

--- a/scripts/content.js
+++ b/scripts/content.js
@@ -1,3 +1,13 @@
+if (!document.getElementById('dejunk-style')) {
+  const style = document.createElement('style');
+  style.id = 'dejunk-style';
+  style.textContent = `
+    .dejunk-hide {
+      display: none !important;
+    }`;
+  document.head.appendChild(style);
+}
+
 function promotedRedditContent(enabled) {
   // When triggered, update user preferences in local storage
   if (enabled === true) {
@@ -113,7 +123,7 @@ function hideYoutubeLives(result) {
     for (const el of elements) {
       const element = el.closest('ytd-rich-item-renderer');
       if (element) {
-        element.style.display = 'none';
+        element.classList.add('dejunk-hide');
       }
     }
   } else if (result === false) {

--- a/scripts/popup.js
+++ b/scripts/popup.js
@@ -15,7 +15,7 @@ chrome.tabs.query({ active: true, lastFocusedWindow: true }, (tabs) => {
   }
 
   // Check local storage for user preferences
-  chrome.storage.local.get(['promotedRedditContent', 'sponsoredQuoraContent', 'youtubeShorts'], (result) => {
+  chrome.storage.local.get(['promotedRedditContent', 'sponsoredQuoraContent', 'youtubeShorts', 'youtubeLives'], (result) => {
     // If the user has enabled hiding promoted Reddit content, check the corresponding checkbox
     if (result.promotedRedditContent === true) {
       document.getElementById('promotedRedditContent').checked = true;
@@ -27,6 +27,10 @@ chrome.tabs.query({ active: true, lastFocusedWindow: true }, (tabs) => {
     // If the user has enabled hiding YouTube Shorts, check the corresponding checkbox
     if (result.youtubeShorts === true) {
       document.getElementById('youtubeShorts').checked = true;
+    }
+    // If the user has enabled hiding YouTube Lives, check the corresponding checkbox
+    if (result.youtubeLives === true) {
+      document.getElementById('youtubeLives').checked = true;
     }
   });
 


### PR DESCRIPTION
This PR adds a toggle and functionality to hide suggested live stream videos on YouTube.

It also adds and tries out some new methods to limit memory load on already memory-intensive sites such as YouTube:

- Adding a `style` element to the given page that gives us access to a class (`dejunk-hide`), adding this class to each element to hide rather than repeatedly rewriting `style` properties, triggering more frequent style recalculations 
- Debouncing `hideTargetElements`, limiting how frequently element-hiding functions are run on the page, and aiding performance, especially on ultra-dynamic pages with a lot of element pop-in
- Adding a `WeakSet` as a lightweight method to keep track of already-hidden elements, preventing us from potentially trying to rehide those same elements every single time the DOM experiences a change that triggers our `MutationObserver`