### PR TITLE
Feature/linkedin promoted

### DIFF
--- a/manifest.json
+++ b/manifest.json
@@ -13,7 +13,12 @@
     },
   "content_scripts": [
     {
-      "matches": ["https://*.quora.com/*", "https://*.reddit.com/*", "https://*.youtube.com/*"],
+      "matches": [
+        "https://*.quora.com/*",
+        "https://*.reddit.com/*",
+        "https://*.youtube.com/*",
+        "https://*.linkedin.com/*"
+      ],
       "js": ["scripts/content.js"]
     }
   ],
@@ -21,8 +26,9 @@
     "storage"
   ],
   "host_permissions": [
-  "https://*.quora.com/*",
-  "https://*.reddit.com/*",
-  "https://*.youtube.com/*"
+    "https://*.quora.com/*",
+    "https://*.reddit.com/*",
+    "https://*.youtube.com/*",
+    "https://*.linkedin.com/*"
   ]
 }

--- a/popup/popup.html
+++ b/popup/popup.html
@@ -48,6 +48,18 @@
         </label>
       </div>
     </div>
+        <hr />
+    <p class="slider-label">LinkedIn</p>
+    <hr />
+    <div class="toggle-section">
+      <div class="toggle-row">
+        <p>Hide Promoted Posts:</p>
+        <label class="switch">
+          <input type="checkbox" id="linkedinPromoted" />
+          <span class="slider round"></span>
+        </label>
+      </div>
+    </div>
     <script src="../scripts/popup.js"></script>
   </body>
 </html>

--- a/scripts/content.js
+++ b/scripts/content.js
@@ -158,6 +158,31 @@ function hideYoutubeLives(result) {
   }
 }
 
+const hiddenLinkedinPromoted = new WeakSet();
+
+function hideLinkedinPromoted(result) {
+  if (result === true) {
+    // Hide all promoted posts on LinkedIn
+
+    const elements = document.querySelectorAll('span[aria-hidden="true"]');
+    for (const el of elements) {
+      // Check if the element contains the text "Promoted"
+      if (el.textContent.includes('Promoted')) {
+        // Get the closest parent element that has a data-id attribute
+        const parentElement = el.closest('div[data-id]');
+
+        if (parentElement && !hiddenLinkedinPromoted.has(parentElement)) {
+          parentElement.classList.add('dejunk-hide');
+          hiddenLinkedinPromoted.add(parentElement);
+        }
+      }
+    }
+  } else if (result === false) {
+    // If the user has disabled hiding promoted posts, do nothing
+    return;
+  }
+}
+
 function hideTargetElements() {
   // Check user preferences in local storage for hiding content, 
   // and hide elements accordingly.
@@ -169,7 +194,7 @@ function hideTargetElements() {
   }
 
   // Get user preferences for hiding content
-  chrome.storage.local.get(['promotedRedditContent', 'sponsoredQuoraContent', 'youtubeShorts', 'youtubeLives'], (result) => {
+  chrome.storage.local.get(['promotedRedditContent', 'sponsoredQuoraContent', 'youtubeShorts', 'youtubeLives', 'linkedinPromoted'], (result) => {
     if (location.href.includes('reddit.com')) {
       // Hide all 'promoted' content on Reddit
       hidePromotedRedditContent(result.promotedRedditContent);
@@ -185,6 +210,11 @@ function hideTargetElements() {
       hideYoutubeShorts(result.youtubeShorts);
       // Hide all livestreams on YouTube
       hideYoutubeLives(result.youtubeLives);
+    }
+
+    if (location.href.includes('linkedin.com')) {
+      // Hide all promoted posts on LinkedIn
+      hideLinkedinPromoted(result.linkedinPromoted);
     }
     return;
   });
@@ -203,7 +233,7 @@ function scheduleHideTargetElements() {
 
   liveScanTimeout = setTimeout(() => {
     hideTargetElements();
-  }, 1000);
+  }, 500);
 }
 
 // Use MutationObserver to watch for changes in the DOM and hide elements accordingly

--- a/scripts/content.js
+++ b/scripts/content.js
@@ -60,6 +60,19 @@ function youtubeLives(enabled) {
   }
 }
 
+function linkedinPromoted(enabled) {
+  // When triggered, update user preferences in local storage
+  if (enabled === true) {
+    chrome.storage.local.set({ linkedinPromoted: true }, () => {
+      console.log('LinkedIn promoted content hiding enabled');
+    });
+  } else if (enabled === false) {
+    chrome.storage.local.set({ linkedinPromoted: false }, () => {
+      console.log('LinkedIn promoted content hiding disabled');
+    });
+  }
+}
+
 // Listen for messages from popup.js to toggle content hiding preferences
 chrome.runtime.onMessage.addListener((message, sender, sendResponse) => {
   if (message.type === 'promotedRedditContent') {
@@ -73,6 +86,9 @@ chrome.runtime.onMessage.addListener((message, sender, sendResponse) => {
   }
   if (message.type === 'youtubeLives') {
     youtubeLives(message.enabled);
+  }
+  if (message.type === 'linkedinPromoted') {
+    linkedinPromoted(message.enabled);
   }
   // sendResponse({ status: 'success' });
 })

--- a/scripts/popup.js
+++ b/scripts/popup.js
@@ -15,7 +15,7 @@ chrome.tabs.query({ active: true, lastFocusedWindow: true }, (tabs) => {
   }
 
   // Check local storage for user preferences
-  chrome.storage.local.get(['promotedRedditContent', 'sponsoredQuoraContent', 'youtubeShorts', 'youtubeLives'], (result) => {
+  chrome.storage.local.get(['promotedRedditContent', 'sponsoredQuoraContent', 'youtubeShorts', 'youtubeLives', 'linkedinPromoted'], (result) => {
     // If the user has enabled hiding promoted Reddit content, check the corresponding checkbox
     if (result.promotedRedditContent === true) {
       document.getElementById('promotedRedditContent').checked = true;
@@ -31,6 +31,10 @@ chrome.tabs.query({ active: true, lastFocusedWindow: true }, (tabs) => {
     // If the user has enabled hiding YouTube Lives, check the corresponding checkbox
     if (result.youtubeLives === true) {
       document.getElementById('youtubeLives').checked = true;
+    }
+    // If the user has enabled hiding promoted LinkedIn posts, check the corresponding checkbox
+    if (result.linkedinPromoted === true) {
+      document.getElementById('linkedinPromoted').checked = true;
     }
   });
 


### PR DESCRIPTION
This PR updates Dejunk, adding a toggle and functionality for hiding promoted posts on LinkedIn. It uses all previously discovered methods for mitigating memory usage in the active tab, and also updates the timing on the `setTimeout` call in the debounce function from `1000` -> `500`, limiting layout shift for users on LinkedIn.